### PR TITLE
URISyntaxException in ClasspathMfs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
         <version>1.18</version>
     </parent>
     <artifactId>jcabi-manifests</artifactId>
-    <version>1.1_la2</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jcabi-manifests</name>
     <description>Manager of MANIFEST.MF files</description>
     <properties>
-        <snapshotVersion>1.1_la2</snapshotVersion>
+        <snapshotVersion>2.0-SNAPSHOT</snapshotVersion>
     </properties>
     <issueManagement>
         <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
         <version>1.18</version>
     </parent>
     <artifactId>jcabi-manifests</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>1.1_la2</version>
     <packaging>jar</packaging>
     <name>jcabi-manifests</name>
     <description>Manager of MANIFEST.MF files</description>
     <properties>
-        <snapshotVersion>2.0-SNAPSHOT</snapshotVersion>
+        <snapshotVersion>1.1_la2</snapshotVersion>
     </properties>
     <issueManagement>
         <system>github</system>

--- a/src/main/java/com/jcabi/manifests/ClasspathMfs.java
+++ b/src/main/java/com/jcabi/manifests/ClasspathMfs.java
@@ -1,49 +1,43 @@
 /**
- * Copyright (c) 2012-2015, jcabi.com
- * All rights reserved.
+ * Copyright (c) 2012-2015, jcabi.com All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met: 1) Redistributions of source code must retain the above
- * copyright notice, this list of conditions and the following
- * disclaimer. 2) Redistributions in binary form must reproduce the above
- * copyright notice, this list of conditions and the following
- * disclaimer in the documentation and/or other materials provided
- * with the distribution. 3) Neither the name of the jcabi.com nor
- * the names of its contributors may be used to endorse or promote
+ * modification, are permitted provided that the following conditions are met:
+ * 1) Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer. 2) Redistributions in
+ * binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution. 3) Neither the name of the
+ * jcabi.com nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written
  * permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
- * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jcabi.manifests;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.LinkedList;
 
 /**
  * Manifests in classpath.
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @version $Id: a79bf214200793959e7ddef6ec467fe6d3b909c8 $
  * @since 1.0
  */
 public final class ClasspathMfs implements Mfs {
@@ -51,20 +45,12 @@ public final class ClasspathMfs implements Mfs {
     @Override
     public Collection<InputStream> fetch() throws IOException {
         final Enumeration<URL> resources = Thread.currentThread()
-            .getContextClassLoader()
-            .getResources("META-INF/MANIFEST.MF");
-        final Collection<URI> uris = new LinkedList<URI>();
+                .getContextClassLoader()
+                .getResources("META-INF/MANIFEST.MF");
+        final Collection<InputStream> streams
+                = new ArrayList<InputStream>();
         while (resources.hasMoreElements()) {
-            try {
-                uris.add(resources.nextElement().toURI());
-            } catch (final URISyntaxException ex) {
-                throw new IOException(ex);
-            }
-        }
-        final Collection<InputStream> streams =
-            new ArrayList<InputStream>(uris.size());
-        for (final URI uri : uris) {
-            streams.add(uri.toURL().openStream());
+            streams.add(resources.nextElement().openStream());
         }
         return streams;
     }

--- a/src/main/java/com/jcabi/manifests/ClasspathMfs.java
+++ b/src/main/java/com/jcabi/manifests/ClasspathMfs.java
@@ -40,7 +40,7 @@ import java.util.Enumeration;
  * Manifests in classpath.
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id: a79bf214200793959e7ddef6ec467fe6d3b909c8 $
+ * @version $Id$
  * @since 1.0
  */
 public final class ClasspathMfs implements Mfs {

--- a/src/main/java/com/jcabi/manifests/ClasspathMfs.java
+++ b/src/main/java/com/jcabi/manifests/ClasspathMfs.java
@@ -1,28 +1,31 @@
 /**
- * Copyright (c) 2012-2015, jcabi.com All rights reserved.
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 1) Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 2) Redistributions in
- * binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other
- * materials provided with the distribution. 3) Neither the name of the
- * jcabi.com nor the names of its contributors may be used to endorse or promote
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written
  * permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jcabi.manifests;
 
@@ -47,8 +50,7 @@ public final class ClasspathMfs implements Mfs {
         final Enumeration<URL> resources = Thread.currentThread()
                 .getContextClassLoader()
                 .getResources("META-INF/MANIFEST.MF");
-        final Collection<InputStream> streams
-                = new ArrayList<InputStream>();
+        final Collection<InputStream> streams = new ArrayList<InputStream>(1);
         while (resources.hasMoreElements()) {
             streams.add(resources.nextElement().openStream());
         }


### PR DESCRIPTION
The original implementation which first transforms the resource URLs to URIs and then loop through the URIs to create the streams based on the toURL-method of the URIs leads to a problem in our environment. Our classpath contains spaces and that leads to a URISyntaxException when transforming the URL to an URI. Is there a reason for the double transformation?