### PR TITLE
make jcabi-manifests a valid OSGI bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     </parent>
     <artifactId>jcabi-manifests</artifactId>
     <version>2.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>jcabi-manifests</name>
     <description>Manager of MANIFEST.MF files</description>
     <properties>
@@ -99,6 +99,12 @@
                 <configuration>
                     <parallel>none</parallel>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.0</version>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
use the maven-bundle-plugin to make jcabi-manifests a valid OSGI bundle
