### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-manifests)](http://www.0pdd.com/p?name=jcabi/jcabi-manifests)
 [![Build status](https://ci.appveyor.com/api/projects/status/p49ene126ubcl6va/branch/master?svg=true)](https://ci.appveyor.com/project/yegor256/jcabi-manifests/branch/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-manifests/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-manifests)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-manifests/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-manifests)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-manifests.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-manifests)
 [![Dependencies](https://www.versioneye.com/user/projects/561ac3d0a193340f3200104f/badge.svg?style=flat)](https://www.versioneye.com/user/projects/561ac3d0a193340f3200104f)
 
 [![jpeek report](http://i.jpeek.org/com.jcabi/jcabi-manifests/badge.svg)](http://i.jpeek.org/com.jcabi/jcabi-manifests/)


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io