### PR TITLE
#38: Refactor the Manifests class to an immutable

### DIFF
--- a/src/main/java/com/jcabi/manifests/MfMap.java
+++ b/src/main/java/com/jcabi/manifests/MfMap.java
@@ -31,6 +31,7 @@ package com.jcabi.manifests;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Map of manifest attributes.
@@ -40,15 +41,67 @@ import java.util.Map;
  * @since 1.1
  * @see Manifests
  */
-public interface MfMap extends Map<String, String> {
+public interface MfMap {
+
+    /**
+     * Get size of attributes map.
+     * @return Size of attributes map
+     * @since 2.0
+     */
+    int size();
+
+    /**
+     * Check if attributes map is empty.
+     * @return True if attributes map is empty and false otherwise
+     * @since 2.0
+     */
+    boolean isEmpty();
+
+    /**
+     * Check if attributes map contains the given key.
+     * @param key Attribute name
+     * @return True if attributes map contains the given key and false otherwise
+     * @since 2.0
+     */
+    boolean containsKey(String key);
+
+    /**
+     * Check if attributes map contains the given value.
+     * @param value Attribute value
+     * @return True if attributes map contains the given value and false otherwise
+     * @since 2.0
+     */
+    boolean containsValue(String value);
+
+    /**
+     * Get attribute value by its key.
+     * @param key Attribute name
+     * @return Value of the attribute and null if attribute not found
+     */
+    String get(String key);
+
+    /**
+     * Get a copy of attributes map.
+     * @return Copy of attributes map
+     * @since 2.0
+     */
+    Map<String, String> getAsMap();
+
+    /**
+     * Get a copy of a set of attributes keys.
+     * @return Copy of a set of attributes keys
+     * @since 2.0
+     */
+    Set<String> keySet();
 
     /**
      * Append this collection of MANIFEST.MF files.
+     * This method may not change the original instance
+     * and should create a new instance and return it as a result.
      * @param streams Files to append
-     * @return This
-     * @since 1.0
+     * @return New instance that contains original and appended attributes
      * @throws IOException If fails on I/O problem
+     * @since 1.0
      */
     MfMap append(Mfs streams) throws IOException;
-
 }

--- a/src/test/java/com/jcabi/manifests/ManifestsTest.java
+++ b/src/test/java/com/jcabi/manifests/ManifestsTest.java
@@ -102,11 +102,10 @@ public final class ManifestsTest {
             file,
             Logger.format("%s: %s\n", name, value)
         );
-        final Manifests mfs = new Manifests();
-        mfs.append(new FilesMfs(file));
+        final MfMap manifests = new Manifests().append(new FilesMfs(file));
         MatcherAssert.assertThat(
             "loaded from file",
-            mfs.containsKey(name) && mfs.get(name).equals(value)
+            manifests.containsKey(name) && manifests.get(name).equals(value)
         );
     }
 
@@ -117,12 +116,11 @@ public final class ManifestsTest {
      */
     @Test
     public void appendsAttributesFromInputStream() throws Exception {
-        final Manifests mfs = new Manifests();
-        mfs.append(
-            new StreamsMfs(this.getClass().getResourceAsStream("test.mf"))
+        final MfMap manifests = new Manifests().append(
+                new StreamsMfs(this.getClass().getResourceAsStream("test.mf"))
         );
         MatcherAssert.assertThat(
-            mfs.get("From-File"),
+            manifests.get("From-File"),
             Matchers.equalTo("some test attribute")
         );
     }


### PR DESCRIPTION
I've made Manifests file immutable. As well I added `asMap()` method that returns a copy of an internal map of attributes. Method `keySet()` returns a copy of keys set too.