### PR TITLE
add option to return default value on Manifests.read

### DIFF
--- a/src/main/java/com/jcabi/manifests/Assertions.java
+++ b/src/main/java/com/jcabi/manifests/Assertions.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2012-2017, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.manifests;
+
+/**
+ * Assertions of parameters.
+ *
+ * @author Claudenir Freitas (claudenirfreitas.cf@gmail.com)
+ * @version $Id$
+ * @since 1.19
+ */
+public final class Assertions {
+
+    /**
+     * No constructor.
+     */
+    private Assertions() {
+    }
+
+    /**
+     * Validates if parameter is null.
+     *
+     * <p>If parameter is null, return {@link IllegalArgumentException}.
+     *
+     * @param value Value to validate
+     */
+    public static void notNull(final String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("attribute can't be NULL");
+        }
+    }
+
+    /**
+     * Validates if parameter is empty.
+     *
+     * <p>If parameter is empty, return {@link IllegalArgumentException}.
+     *
+     * @param value Value to validate
+     */
+    public static void notEmpty(final String value) {
+        if (value != null && value.isEmpty()) {
+            throw new IllegalArgumentException("attribute can't be empty");
+        }
+    }
+}

--- a/src/main/java/com/jcabi/manifests/Manifests.java
+++ b/src/main/java/com/jcabi/manifests/Manifests.java
@@ -269,6 +269,30 @@ public final class Manifests implements MfMap {
     }
 
     /**
+     * Read one attribute available in one of {@code MANIFEST.MF} files.
+     *
+     * <p>If such a attribute doesn't exist, return default value.
+     *
+     * <p>The method is thread-safe.
+     *
+     * @param name Name of the attribute
+     * @param defaultValue Default value of the attribute
+     * @return The value of the attribute retrieved or default value
+     */
+    public static String read(final String name, final String defaultValue) {
+        if (name == null) {
+            throw new IllegalArgumentException("attribute can't be NULL");
+        }
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("attribute can't be empty");
+        }
+        if (!Manifests.exists(name)) {
+            return defaultValue;
+        }
+        return Manifests.DEFAULT.get().get(name);
+    }
+
+    /**
      * Check whether attribute exists in any of {@code MANIFEST.MF} files.
      *
      * <p>Use this method before {@link #read(String)} to check whether an

--- a/src/main/java/com/jcabi/manifests/Manifests.java
+++ b/src/main/java/com/jcabi/manifests/Manifests.java
@@ -248,12 +248,8 @@ public final class Manifests implements MfMap {
      * @return The value of the attribute retrieved
      */
     public static String read(final String name) {
-        if (name == null) {
-            throw new IllegalArgumentException("attribute can't be NULL");
-        }
-        if (name.isEmpty()) {
-            throw new IllegalArgumentException("attribute can't be empty");
-        }
+        Assertions.notNull(name);
+        Assertions.notEmpty(name);
         if (!Manifests.exists(name)) {
             throw new IllegalArgumentException(
                 Logger.format(
@@ -276,20 +272,19 @@ public final class Manifests implements MfMap {
      * <p>The method is thread-safe.
      *
      * @param name Name of the attribute
-     * @param defaultValue Default value of the attribute
+     * @param def Default value of the attribute
      * @return The value of the attribute retrieved or default value
      */
-    public static String read(final String name, final String defaultValue) {
-        if (name == null) {
-            throw new IllegalArgumentException("attribute can't be NULL");
+    public static String read(final String name, final String def) {
+        Assertions.notNull(name);
+        Assertions.notEmpty(name);
+        String value;
+        if (Manifests.exists(name)) {
+            value = Manifests.DEFAULT.get().get(name);
+        } else {
+            value = def;
         }
-        if (name.isEmpty()) {
-            throw new IllegalArgumentException("attribute can't be empty");
-        }
-        if (!Manifests.exists(name)) {
-            return defaultValue;
-        }
-        return Manifests.DEFAULT.get().get(name);
+        return value;
     }
 
     /**

--- a/src/test/java/com/jcabi/manifests/ManifestsTest.java
+++ b/src/test/java/com/jcabi/manifests/ManifestsTest.java
@@ -58,6 +58,18 @@ public final class ManifestsTest {
     }
 
     /**
+     * Manifests can read a single attribute, which always exist in MANIFEST.MF.
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public void readsSingleNotExistingAttribute() throws Exception {
+        MatcherAssert.assertThat(
+            Manifests.read("invalid-key", "default_value"),
+            Matchers.equalTo("default_value")
+        );
+    }
+
+    /**
      * Manifests can throw an exception if an attribute is empty.
      * @throws Exception If something goes wrong
      */

--- a/src/test/java/com/jcabi/manifests/ManifestsTest.java
+++ b/src/test/java/com/jcabi/manifests/ManifestsTest.java
@@ -58,14 +58,15 @@ public final class ManifestsTest {
     }
 
     /**
-     * Manifests can read a single attribute, which always exist in MANIFEST.MF.
+     * Manifests can read a default value.
      * @throws Exception If something goes wrong
      */
     @Test
     public void readsSingleNotExistingAttribute() throws Exception {
+        final String value = "default";
         MatcherAssert.assertThat(
-            Manifests.read("invalid-key", "default_value"),
-            Matchers.equalTo("default_value")
+            Manifests.read("invalid-key", value),
+            Matchers.equalTo(value)
         );
     }
 


### PR DESCRIPTION
It's a simple change to return default value if there is no key on the map.

Motivation: I'm using `Manifests.DEFAULT.getOrDefault("app-version", "NI")`, but I think it's possible to keep simple.

Thanks a lot,
Cheers.