### PR TITLE
#333-jcabi/jcabi com.jcabi.manifests.Manifests NoClassDefFoundError

### DIFF
--- a/src/main/java/com/jcabi/manifests/Manifests.java
+++ b/src/main/java/com/jcabi/manifests/Manifests.java
@@ -144,10 +144,7 @@ public final class Manifests implements MfMap {
                 currentInstance.append(new ClasspathMfs())
             );
         } catch (final IOException ex) {
-            Logger.error(
-                Manifests.class,
-                "#load(): '%s' failed %[exception]s", ex
-            );
+            logLoadFailedError(ex);
         }
     }
 
@@ -393,10 +390,19 @@ public final class Manifests implements MfMap {
             );
         // @checkstyle IllegalCatch (1 line)
         } catch (final RuntimeException ex) {
-            Logger.error(Manifests.class, "#load(): failed %[exception]s", ex);
+            logLoadFailedError(ex);
         } finally {
             stream.close();
         }
         return props;
+    }
+
+    /**
+     * Report the exception that was just thrown.
+     *
+     * @param exn The exception to report
+     */
+    private static void logLoadFailedError(final Exception exn) {
+        Logger.error(Manifests.class, "#load(): failed %[exception]s", exn);
     }
 }


### PR DESCRIPTION
fix ArrayIndexOutOfBoundsException leading to com.jcabi.manifests.Manifests NoClassDefFoundError

When an error occurs loading the manifest, a piece of static code that's trying to report the error instead throws an exception during a catch block. This prevents loading of the class, and results in NoClassDefFoundError errors which are hard to diagnose, as the class is present in the jar file.

The real error encountered by users is described in the exception that is being caught, but this is never reported due to the exception thrown during the attempt to report.

This issue was reported against the parent project at https://github.com/jcabi/jcabi/issues/333
