### PR TITLE
Upgrade jcabi parent to 1.44.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.40.1</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-manifests</artifactId>
   <version>2.1.0-SNAPSHOT</version>

--- a/src/main/java/com/jcabi/manifests/Manifests.java
+++ b/src/main/java/com/jcabi/manifests/Manifests.java
@@ -16,7 +16,6 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 /**
@@ -93,7 +92,7 @@ import java.util.jar.Manifest;
  * @link <a href="http://manifests.jcabi.com/index.html">manifests.jcabi.com</a>
  * @link <a href="http://www.yegor256.com/2014/07/03/how-to-read-manifest-mf.html">How to Read MANIFEST.MF Files</a>
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.ProhibitPublicStaticMethods"})
+@SuppressWarnings("PMD.ProhibitPublicStaticMethods")
 public final class Manifests implements MfMap {
 
     /**
@@ -179,7 +178,7 @@ public final class Manifests implements MfMap {
     }
 
     @Override
-    @SuppressWarnings({ "PMD.GuardLogStatement", "PMD.CloseResource" })
+    @SuppressWarnings({"PMD.CloseResource", "PMD.UnnecessaryLocalRule"})
     public void append(final Mfs mfs) throws IOException {
         final long start = System.currentTimeMillis();
         final Collection<InputStream> list = mfs.fetch();
@@ -285,13 +284,12 @@ public final class Manifests implements MfMap {
         final ConcurrentMap<String, String> props =
             new ConcurrentHashMap<>(0);
         try {
-            final Manifest manifest = new Manifest(stream);
-            final Attributes attrs = manifest.getMainAttributes();
-            for (final Object key : attrs.keySet()) {
-                final String value = attrs.getValue(
-                    Attributes.Name.class.cast(key)
+            for (final Map.Entry<Object, Object> entry
+                : new Manifest(stream).getMainAttributes().entrySet()) {
+                props.put(
+                    entry.getKey().toString(),
+                    entry.getValue().toString()
                 );
-                props.put(key.toString(), value);
             }
             Logger.debug(
                 Manifests.class,

--- a/src/main/java/com/jcabi/manifests/Mfs.java
+++ b/src/main/java/com/jcabi/manifests/Mfs.java
@@ -13,6 +13,7 @@ import java.util.Collection;
  *
  * @since 1.0
  */
+@FunctionalInterface
 public interface Mfs {
 
     /**

--- a/src/test/java/com/jcabi/manifests/ManifestsTest.java
+++ b/src/test/java/com/jcabi/manifests/ManifestsTest.java
@@ -52,14 +52,14 @@ final class ManifestsTest {
     void throwsExceptionWhenNoAttributes() {
         Assertions.assertThrows(
             IOException.class,
-            () -> {
-                final File file = new File(
-                    Thread.currentThread().getContextClassLoader()
-                        .getResource("META-INF/MANIFEST_INVALID.MF").getFile()
-                );
-                final Manifests mfs = new Manifests();
-                mfs.append(new FilesMfs(file));
-            },
+            () -> new Manifests().append(
+                new FilesMfs(
+                    new File(
+                        Thread.currentThread().getContextClassLoader()
+                            .getResource("META-INF/MANIFEST_INVALID.MF").getFile()
+                    )
+                )
+            ),
             "doesn't throw"
         );
     }

--- a/src/test/java/com/jcabi/manifests/StringMfsTest.java
+++ b/src/test/java/com/jcabi/manifests/StringMfsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 final class StringMfsTest {
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void turnsStringIntoMfs() throws IOException {
         try (InputStream input = new StringMfs("Foo: bar").fetch().iterator().next()) {
             MatcherAssert.assertThat(


### PR DESCRIPTION
@yegor256, this PR upgrades all dependencies and plugins to the latest stable versions and fixes the resulting linter findings.

## Summary
- Bump parent POM `com.jcabi:jcabi` from 1.40.1 to 1.44.0 (latest stable).
- Fix the nine new qulice (PMD 7 / qulice 0.25.1) violations the bumped parent surfaces, so `mvn clean install -Pqulice` is green again.

## Why this is the only direct-dependency change
All other direct dependencies in `pom.xml` are already on their latest stable versions:
- `jakarta.servlet:jakarta.servlet-api 5.0.0` is intentionally pinned per the in-source comment, to keep compatibility with all Jakarta 9.1+ web containers; bumping to 6.x would break that.
- `jakarta.el:jakarta.el-api 6.0.1` is the latest stable (6.1.0-M1 is a milestone).
- `javax.servlet:servlet-api 2.5` is intentionally pinned per the in-source comment for legacy container compatibility.

## Linter fixes
The new qulice surfaced these and they are all addressed:
- `Manifests.java`: drop the now-unused `PMD.TooManyMethods` and `PMD.GuardLogStatement` suppressions.
- `Manifests.java#load`: replace the `LooseCoupling`-flagged `java.util.jar.Attributes` local with iteration over `getMainAttributes().entrySet()` using `Map.Entry<Object, Object>`; this also drops two `UnnecessaryLocalRule`-flagged single-use locals (`attrs`, `value`).
- `Mfs.java`: add `@FunctionalInterface` (per `ImplicitFunctionalInterface`).
- `ManifestsTest.java`: inline the single-use `file` and `mfs` locals.
- `Manifests.java#append` and `StringMfsTest.turnsStringIntoMfs`: suppress `PMD.UnnecessaryLocalRule` in the two cases where the local is genuinely required by Java semantics (timing capture before work, and try-with-resources resource binding).

## Verification
- `mvn --batch-mode clean install -Pqulice` passes locally on JDK 21 with all 8 tests green and qulice clean.
- `xcop`, `reuse lint`, and `yamllint` all pass locally on the changed files.

CI is currently waiting for first-time-contributor approval. Could you click "Approve and run" so the matrix workflows can run? Ready for merge once green.