### PR TITLE
#38 add asMap() alias on MfMap to match the original spec

### DIFF
--- a/src/main/java/com/jcabi/manifests/MfMap.java
+++ b/src/main/java/com/jcabi/manifests/MfMap.java
@@ -61,6 +61,22 @@ public interface MfMap {
     Map<String, String> getAsMap();
 
     /**
+     * Get a copy of attributes map, named per the original specification
+     * of issue #38.
+     *
+     * <p>This is an alias for {@link #getAsMap()} that exposes the same
+     * snapshot under the shorter, idiomatic name from the acceptance
+     * criteria. Implementations may override it, but the default delegates
+     * to {@link #getAsMap()} so existing implementations need no change.
+     *
+     * @return Copy of attributes map
+     * @since 2.1
+     */
+    default Map<String, String> asMap() {
+        return this.getAsMap();
+    }
+
+    /**
      * Get a copy of a set of attributes keys.
      * @return Copy of a set of attributes keys
      * @since 2.0

--- a/src/test/java/com/jcabi/manifests/ManifestsTest.java
+++ b/src/test/java/com/jcabi/manifests/ManifestsTest.java
@@ -105,4 +105,26 @@ final class ManifestsTest {
         );
     }
 
+    @Test
+    void asMapMirrorsGetAsMap() throws Exception {
+        final MfMap manifests = new Manifests();
+        manifests.append(new StringMfs("Alias-Key: alias-value\n"));
+        MatcherAssert.assertThat(
+            "asMap() must expose the same snapshot as getAsMap()",
+            manifests.asMap(),
+            Matchers.equalTo(manifests.getAsMap())
+        );
+    }
+
+    @Test
+    void asMapExposesAppendedAttribute() throws Exception {
+        final MfMap manifests = new Manifests();
+        manifests.append(new StringMfs("Alias-Key: alias-value\n"));
+        MatcherAssert.assertThat(
+            "asMap() must contain the appended attribute",
+            manifests.asMap().get("Alias-Key"),
+            Matchers.equalTo("alias-value")
+        );
+    }
+
 }


### PR DESCRIPTION
The MfMap interface exposes manifest entries through getAsMap(), but the original spec referenced in issue #38 named that accessor asMap(). Callers following the spec hit a compile error against the current code, so this change restores the documented name.

The MfMap interface now exposes asMap() as a default method that delegates to getAsMap(). Existing implementations keep working without modification, no method is removed, and callers can use either name interchangeably.

Local verification ran mvn --batch-mode --errors clean install -Pqulice on JDK 21 with BUILD SUCCESS. Qulice reported no violations and the test suite passed, including two new cases in ManifestsTest that exercise the asMap() alias.

Closes #38